### PR TITLE
allowing for NO colum separators

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -41,7 +41,7 @@ impl LineSeparator {
 /// Contains the table formatting rules
 #[derive(Clone, Debug)]
 pub struct TableFormat {
-	col_sep: [u8; 1],
+	col_sep: &'static str,
 	line_sep: Option<LineSeparator>,
 	title_sep: Option<LineSeparator>
 }
@@ -54,8 +54,8 @@ impl TableFormat {
 	/// `line_sep` is an optional `LineSeparator` defining how to separate lines.
 	/// `title_sep` is an optional `LineSeparator` defining the format of the separator after the title line (if set).
 	/// If `title_sep` is set to `None`, then `line_sep` will be used, f it's set.
-	pub fn new(col_sep: char, line_sep: Option<LineSeparator>, title_sep: Option<LineSeparator>) -> TableFormat {
-		return TableFormat{col_sep: [col_sep as u8], line_sep: line_sep, title_sep: title_sep};
+	pub fn new(col_sep: &'static str, line_sep: Option<LineSeparator>, title_sep: Option<LineSeparator>) -> TableFormat {
+		return TableFormat{col_sep: col_sep, line_sep: line_sep, title_sep: title_sep};
 	}
 	
 	/// Print a full line separator to `out`. `col_width` is a slice containing the width of each column
@@ -76,7 +76,7 @@ impl TableFormat {
 	
 	/// Print a column separator to `out`
 	pub fn print_column_separator<T: Write+?Sized>(&self, out: &mut T) -> Result<(), Error> {
-		return out.write_all(&self.col_sep);
+		return out.write_all(&self.col_sep.as_bytes());
 	}
 }
 
@@ -96,10 +96,10 @@ pub const EQU_PLUS_SEP: LineSeparator = LineSeparator{line: ['=' as u8], cross: 
 /// |    |    |
 /// +----+----+
 /// ```
-pub const FORMAT_DEFAULT: TableFormat = TableFormat{col_sep: ['|' as u8], line_sep: Some(MINUS_PLUS_SEP), title_sep: Some(EQU_PLUS_SEP)};
+pub const FORMAT_DEFAULT: TableFormat = TableFormat{col_sep: "|", line_sep: Some(MINUS_PLUS_SEP), title_sep: Some(EQU_PLUS_SEP)};
 
 /// Similar to `FORMAT_DEFAULT` but without special separator after title line
-pub const FORMAT_NO_LINESEP: TableFormat = TableFormat{col_sep: ['|' as u8], line_sep: None, title_sep: Some(MINUS_PLUS_SEP)};
+pub const FORMAT_NO_LINESEP: TableFormat = TableFormat{col_sep: "|", line_sep: None, title_sep: Some(MINUS_PLUS_SEP)};
 
 /// Format for printing a table without any separators (only alignment)
-pub const FORMAT_BLANK: TableFormat = TableFormat{col_sep: [' ' as u8], line_sep: None, title_sep: None};
+pub const FORMAT_BLANK: TableFormat = TableFormat{col_sep: " ", line_sep: None, title_sep: None};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,7 +321,8 @@ mod tests {
 	use Table;
 	use row::Row;
 	use cell::Cell;
-	
+     use format::TableFormat;
+
 	#[test]
 	fn table() {
 		let mut table = Table::new();
@@ -361,5 +362,48 @@ mod tests {
 +-----+--------+-----+
 ";
 		assert_eq!(table.to_string().replace("\r\n", "\n"), out);
+	}
+
+	#[test]
+	fn no_linesep() {
+		let mut table = Table::new();
+          table.set_format(TableFormat::new("|", None, None));
+		table.add_row(Row::new(vec![Cell::new("a"), Cell::new("bc"), Cell::new("def")]));
+		table.add_row(Row::new(vec![Cell::new("def"), Cell::new("bc"), Cell::new("a")]));
+		table.set_titles(Row::new(vec![Cell::new("t1"), Cell::new("t2"), Cell::new("t3")]));
+		assert_eq!(table[1][1].get_content(), "bc");
+
+		table[1][1] = Cell::new("newval");
+		assert_eq!(table[1][1].get_content(), "newval");
+
+		let out = "\
+| t1  | t2     | t3  |
+| a   | bc     | def |
+| def | newval | a   |
+";
+		assert_eq!(table.to_string().replace("\r\n", "\n"), out);
+	}
+
+	#[test]
+	fn no_borders() {
+		let mut table = Table::new();
+          table.set_format(TableFormat::new("", None, None));
+		table.add_row(Row::new(vec![Cell::new("a"), Cell::new("bc"), Cell::new("def")]));
+		table.add_row(Row::new(vec![Cell::new("def"), Cell::new("bc"), Cell::new("a")]));
+		table.set_titles(Row::new(vec![Cell::new("t1"), Cell::new("t2"), Cell::new("t3")]));
+		assert_eq!(table[1][1].get_content(), "bc");
+
+		table[1][1] = Cell::new("newval");
+		assert_eq!(table[1][1].get_content(), "newval");
+
+		let out = "
+ t1   t2      t3  
+ a    bc      def 
+ def  newval  a   
+";
+          println!("{}", out);
+          println!("____");
+          println!("{}", table.to_string().replace("\r\n", "\n"));
+		assert_eq!(out, String::from("\n") + &table.to_string().replace("\r\n", "\n"));
 	}
 }


### PR DESCRIPTION
This makes column separator a `&str`.
I considered an `Option<char>` to, but this seemed more straight forward.

What do you think?