### PR TITLE
Add some iters for use with rows to make formatting cells a bit easier

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ use std::io;
 use std::io::{Write, Error};
 use std::fmt;
 use std::iter::{FromIterator, IntoIterator};
+use std::slice::{Iter, IterMut};
 use std::ops::{Index, IndexMut};
 use std::mem::transmute;
 
@@ -273,6 +274,15 @@ impl Table {
 	pub fn column_iter_mut(&mut self, column: usize) -> ColumnIterMut {
 		return ColumnIterMut(self.rows.iter_mut(), column);
 	}
+
+    pub fn row_iter<'a>(&'a self) -> Iter<'a, Row> {
+        self.rows.iter()
+    }
+
+    pub fn row_iter_mut<'a>(&'a mut self) -> IterMut<'a, Row> {
+        self.rows.iter_mut()
+    }
+
 
 	/// Print the table to `out`
 	pub fn print<T: Write+?Sized>(&self, out: &mut T) -> Result<(), Error> {

--- a/src/row.rs
+++ b/src/row.rs
@@ -1,6 +1,7 @@
 //! This module contains definition of table rows stuff
 use std::io::{Write, Error};
 use std::iter::FromIterator;
+use std::slice::{Iter, IterMut};
 use std::ops::{Index, IndexMut};
 
 use term::Terminal;
@@ -94,6 +95,16 @@ impl Row {
 			self.cells.remove(index);
 		}
 	}
+
+    // You need to impl Iterator for these to work with for / map implicitly
+    // But there is a compiler warning when you do add the trait.
+    pub fn iter<'a>(&'a self) -> Iter<'a, Cell> {
+        self.cells.iter()
+    }
+
+    pub fn iter_mut<'a>(&'a mut self) -> IterMut<'a, Cell> {
+        self.cells.iter_mut()
+    }
 
 	/// Internal only
 	fn __print<T:Write+?Sized, F>(&self, out: &mut T, format: &TableFormat, col_width: &[usize], f: F) -> Result<(), Error>


### PR DESCRIPTION
Here is a bit of a go at adding some iter() types.

I had issues actually implementing the Iterator trait (I'm still new to rust)

For now I'm happy with these, as they work to fix my use case, but I am sure you could improve this.

