### PR TITLE
Bump csv for the latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ term = "^0.4"
 lazy_static = "^0.2"
 atty = "^0.2"
 encode_unicode = "^0.2"
-csv = { version = "^0.14", optional = true }
+csv = { version = "^0.15", optional = true }


### PR DESCRIPTION
Wasn't sure if there was a good way to express "either 0.14 OR 0.15"