### PR TITLE
Fix predefined formats to match their descriptions

### DIFF
--- a/examples/formatting.rs
+++ b/examples/formatting.rs
@@ -35,7 +35,6 @@ fn main() {
     // | Title 1      Title 2    |
     // +=========================+
     // | Value 1      Value 2    |
-    // +-------------------------+
     // | Value three  Value four |
     // +-------------------------+
     println!("FORMAT_BORDERS_ONLY :");

--- a/src/format.rs
+++ b/src/format.rs
@@ -318,7 +318,7 @@ pub mod consts {
 		pub static ref FORMAT_NO_LINESEP_WITH_TITLE: TableFormat = FormatBuilder::new()
 																	.column_separator('|')
 																	.borders('|')
-																	.separator(LinePosition::Title, *MINUS_PLUS_SEP)
+																	.separator(LinePosition::Title, *EQU_PLUS_SEP)
 																	.separator(LinePosition::Bottom, *MINUS_PLUS_SEP)
 																	.separator(LinePosition::Top, *MINUS_PLUS_SEP)
 																	.padding(1, 1)
@@ -337,6 +337,8 @@ pub mod consts {
 		pub static ref FORMAT_NO_LINESEP: TableFormat = FormatBuilder::new()
 																	.column_separator('|')
 																	.borders('|')
+																	.separator(LinePosition::Bottom, *MINUS_PLUS_SEP)
+																	.separator(LinePosition::Top, *MINUS_PLUS_SEP)
 																	.padding(1, 1)
 																	.build();
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -310,7 +310,7 @@ pub mod consts {
 		/// ```text
 		/// +----+----+
 		/// | T1 | T2 |
-		/// +====+====+
+		/// +----+----+
 		/// | a  | b  |
 		/// | c  | d  |
 		/// +----+----+
@@ -318,7 +318,7 @@ pub mod consts {
 		pub static ref FORMAT_NO_LINESEP_WITH_TITLE: TableFormat = FormatBuilder::new()
 																	.column_separator('|')
 																	.borders('|')
-																	.separator(LinePosition::Title, *EQU_PLUS_SEP)
+																	.separator(LinePosition::Title, *MINUS_PLUS_SEP)
 																	.separator(LinePosition::Bottom, *MINUS_PLUS_SEP)
 																	.separator(LinePosition::Top, *MINUS_PLUS_SEP)
 																	.padding(1, 1)
@@ -387,7 +387,6 @@ pub mod consts {
 		/// ```
 		pub static ref FORMAT_BORDERS_ONLY: TableFormat = FormatBuilder::new()
 																	.padding(1, 1)
-																	.separator(LinePosition::Intern, *MINUS_PLUS_SEP)
 																	.separator(LinePosition::Title, *EQU_PLUS_SEP)
 																	.separator(LinePosition::Bottom, *MINUS_PLUS_SEP)
 																	.separator(LinePosition::Top, *MINUS_PLUS_SEP)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -634,9 +634,11 @@ mod tests {
 		assert_eq!(table[1][1].get_content(), "newval");
 
 		let out = "\
++-----+--------+-----+
 | t1  | t2     | t3  |
 | a   | bc     | def |
 | def | newval | a   |
++-----+--------+-----+
 ";
 		assert_eq!(table.to_string().replace("\r\n", "\n"), out);
 	}


### PR DESCRIPTION
`FORMAT_NO_LINESEP_WITH_TITLE` and `FORMAT_NO_LINESEP` definitions don't match the examples in their docs.