### PR TITLE
Fix padding formatting

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -57,14 +57,25 @@ impl LineSeparator {
     }
 
     /// Print a full line separator to `out`. `col_width` is a slice containing the width of each column
+    #[deprecated(since = "0.6.7", note = "assumes padding is always (1, 1)")]
     pub fn print<T: Write + ?Sized>(&self,
                                     out: &mut T,
                                     col_width: &[usize],
-                                    padding: (usize, usize),
                                     colsep: bool,
                                     lborder: bool,
                                     rborder: bool)
                                     -> Result<(), Error> {
+        self.real_print(out, col_width, (1, 1), colsep, lborder, rborder)
+    }
+
+    fn real_print<T: Write + ?Sized>(&self,
+                                     out: &mut T,
+                                     col_width: &[usize],
+                                     padding: (usize, usize),
+                                     colsep: bool,
+                                     lborder: bool,
+                                     rborder: bool)
+                                     -> Result<(), Error> {
         if lborder {
             try!(out.write_all(Utf8Char::from(self.ljunc).as_bytes()));
         }
@@ -190,12 +201,12 @@ impl TableFormat {
                                                    -> Result<(), Error> {
         match *self.get_sep_for_line(pos) {
             Some(ref l) => {
-                l.print(out,
-                        col_width,
-                        self.get_padding(),
-                        self.csep.is_some(),
-                        self.lborder.is_some(),
-                        self.rborder.is_some())
+                l.real_print(out,
+                             col_width,
+                             self.get_padding(),
+                             self.csep.is_some(),
+                             self.lborder.is_some(),
+                             self.rborder.is_some())
             }
             None => Ok(()),
         }

--- a/src/format.rs
+++ b/src/format.rs
@@ -57,7 +57,7 @@ impl LineSeparator {
     }
 
     /// Print a full line separator to `out`. `col_width` is a slice containing the width of each column
-    #[deprecated(since = "0.6.7", note = "assumes padding is always (1, 1)")]
+    #[deprecated(since = "0.6.7", note = "function will be removed. See [issue #57](https://github.com/phsym/prettytable-rs/pull/57).")]
     pub fn print<T: Write + ?Sized>(&self,
                                     out: &mut T,
                                     col_width: &[usize],
@@ -65,17 +65,17 @@ impl LineSeparator {
                                     lborder: bool,
                                     rborder: bool)
                                     -> Result<(), Error> {
-        self.real_print(out, col_width, (1, 1), colsep, lborder, rborder)
+        self._print(out, col_width, (1, 1), colsep, lborder, rborder)
     }
 
-    fn real_print<T: Write + ?Sized>(&self,
-                                     out: &mut T,
-                                     col_width: &[usize],
-                                     padding: (usize, usize),
-                                     colsep: bool,
-                                     lborder: bool,
-                                     rborder: bool)
-                                     -> Result<(), Error> {
+    fn _print<T: Write + ?Sized>(&self,
+                                 out: &mut T,
+                                 col_width: &[usize],
+                                 padding: (usize, usize),
+                                 colsep: bool,
+                                 lborder: bool,
+                                 rborder: bool)
+                                 -> Result<(), Error> {
         if lborder {
             try!(out.write_all(Utf8Char::from(self.ljunc).as_bytes()));
         }
@@ -201,12 +201,12 @@ impl TableFormat {
                                                    -> Result<(), Error> {
         match *self.get_sep_for_line(pos) {
             Some(ref l) => {
-                l.real_print(out,
-                             col_width,
-                             self.get_padding(),
-                             self.csep.is_some(),
-                             self.lborder.is_some(),
-                             self.rborder.is_some())
+                l._print(out,
+                         col_width,
+                         self.get_padding(),
+                         self.csep.is_some(),
+                         self.lborder.is_some(),
+                         self.rborder.is_some())
             }
             None => Ok(()),
         }

--- a/src/format.rs
+++ b/src/format.rs
@@ -60,6 +60,7 @@ impl LineSeparator {
     pub fn print<T: Write + ?Sized>(&self,
                                     out: &mut T,
                                     col_width: &[usize],
+                                    padding: (usize, usize),
                                     colsep: bool,
                                     lborder: bool,
                                     rborder: bool)
@@ -69,7 +70,7 @@ impl LineSeparator {
         }
         let mut iter = col_width.into_iter().peekable();
         while let Some(width) = iter.next() {
-            for _ in 0..width + 2 {
+            for _ in 0..width + padding.0 + padding.1 {
                 try!(out.write_all(Utf8Char::from(self.line).as_bytes()));
             }
             if colsep && iter.peek().is_some() {
@@ -191,6 +192,7 @@ impl TableFormat {
             Some(ref l) => {
                 l.print(out,
                         col_width,
+                        self.get_padding(),
                         self.csep.is_some(),
                         self.lborder.is_some(),
                         self.rborder.is_some())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -603,7 +603,7 @@ mod tests {
     use row::Row;
     use cell::Cell;
     use format;
-    use format::consts::{FORMAT_NO_LINESEP, FORMAT_NO_COLSEP, FORMAT_CLEAN};
+    use format::consts::{FORMAT_DEFAULT, FORMAT_NO_LINESEP, FORMAT_NO_COLSEP, FORMAT_CLEAN};
 
     #[test]
     fn table() {
@@ -711,6 +711,35 @@ mod tests {
 \u{0020}t1   t2      t3 \n\
 \u{0020}a    bc      def \n\
 \u{0020}def  newval  a \n\
+";
+        println!("{}", out);
+        println!("____");
+        println!("{}", table.to_string().replace("\r\n", "\n"));
+        assert_eq!(out, table.to_string().replace("\r\n", "\n"));
+    }
+
+    #[test]
+    fn padding() {
+        let mut table = Table::new();
+        let mut format = *FORMAT_DEFAULT;
+        format.padding(2, 2);
+        table.set_format(format);
+        table.add_row(Row::new(vec![Cell::new("a"), Cell::new("bc"), Cell::new("def")]));
+        table.add_row(Row::new(vec![Cell::new("def"), Cell::new("bc"), Cell::new("a")]));
+        table.set_titles(Row::new(vec![Cell::new("t1"), Cell::new("t2"), Cell::new("t3")]));
+        assert_eq!(table[1][1].get_content(), "bc");
+
+        table[1][1] = Cell::new("newval");
+        assert_eq!(table[1][1].get_content(), "newval");
+
+        let out = "\
++-------+----------+-------+
+|  t1   |  t2      |  t3   |
++=======+==========+=======+
+|  a    |  bc      |  def  |
++-------+----------+-------+
+|  def  |  newval  |  a    |
++-------+----------+-------+
 ";
         println!("{}", out);
         println!("____");


### PR DESCRIPTION
Line separators relied on default `(1, 1)` padding, but should use padding provided externally.

The solution here breaks public API, so it could be more future-proof to go the "deprecate and enter new API" route, though I doubt end-users ever paid attention to  `LineSeparator::print`, only `LineSeparator::new` has significance.

I even removed `pub` from `LineSeparator::print`, and both `main.rs` and tests ran normally.