### PR TITLE
Customize indent in format

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -133,6 +133,8 @@ pub struct TableFormat {
     pad_left: usize,
     /// Right padding
     pad_right: usize,
+    /// Global indentation when rendering the table
+    indent: usize,
 }
 
 impl TableFormat {
@@ -148,6 +150,7 @@ impl TableFormat {
             bottom_sep: None,
             pad_left: 0,
             pad_right: 0,
+            indent: 0
         }
     }
 
@@ -204,6 +207,16 @@ impl TableFormat {
         }
     }
 
+    /// Set global indentation in spaces used when rendering a table 
+    pub fn indent(&mut self, spaces: usize) {
+        self.indent = spaces;
+    }
+
+    /// Get global indentation in spaces used when rendering a table 
+    pub fn get_indent(&self) -> usize {
+        self.indent
+    }
+
     /// Print a full line separator to `out`. `col_width` is a slice containing the width of each column
     pub fn print_line_separator<T: Write + ?Sized>(&self,
                                                    out: &mut T,
@@ -212,6 +225,7 @@ impl TableFormat {
                                                    -> Result<(), Error> {
         match *self.get_sep_for_line(pos) {
             Some(ref l) => {
+                write!(out, "{:1$}", "", self.get_indent());
                 l._print(out,
                          col_width,
                          self.get_padding(),
@@ -262,6 +276,11 @@ impl FormatBuilder {
         FormatBuilder { format: Box::new(TableFormat::new()) }
     }
 
+    /// Creates a new builder initialized with provided format
+    pub fn from_format(format: TableFormat) -> FormatBuilder {
+        FormatBuilder { format: Box::new(format) }
+    }
+
     /// Set left and right padding
     pub fn padding(mut self, left: usize, right: usize) -> Self {
         self.format.padding(left, right);
@@ -289,6 +308,12 @@ impl FormatBuilder {
     /// Set separator format for multiple kind of line separators
     pub fn separators(mut self, what: &[LinePosition], separator: LineSeparator) -> Self {
         self.format.separators(what, separator);
+        self
+    }
+
+    /// Set global indentation in spaces used when rendering a table 
+    pub fn indent(mut self, spaces: usize) -> Self {
+        self.format.indent(spaces);
         self
     }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -150,7 +150,7 @@ impl TableFormat {
             bottom_sep: None,
             pad_left: 0,
             pad_right: 0,
-            indent: 0
+            indent: 0,
         }
     }
 
@@ -207,12 +207,12 @@ impl TableFormat {
         }
     }
 
-    /// Set global indentation in spaces used when rendering a table 
+    /// Set global indentation in spaces used when rendering a table
     pub fn indent(&mut self, spaces: usize) {
         self.indent = spaces;
     }
 
-    /// Get global indentation in spaces used when rendering a table 
+    /// Get global indentation in spaces used when rendering a table
     pub fn get_indent(&self) -> usize {
         self.indent
     }
@@ -225,7 +225,8 @@ impl TableFormat {
                                                    -> Result<(), Error> {
         match *self.get_sep_for_line(pos) {
             Some(ref l) => {
-                out.write_all(&vec![b' '; self.get_indent()]);
+                //TODO: Wrap this into dedicated function one day
+                try!(out.write_all(&vec![b' '; self.get_indent()]));
                 l._print(out,
                          col_width,
                          self.get_padding(),
@@ -276,16 +277,6 @@ impl FormatBuilder {
         FormatBuilder { format: Box::new(TableFormat::new()) }
     }
 
-    /// Creates a new builder initialized with provided format
-    pub fn from_format(format: TableFormat) -> FormatBuilder {
-        FormatBuilder { format: Box::new(format) }
-    }
-
-    /// Consumes the builder and returns the generated `TableFormat`
-    pub fn into_table_format(self) -> TableFormat {
-        *self.format
-    }
-
     /// Set left and right padding
     pub fn padding(mut self, left: usize, right: usize) -> Self {
         self.format.padding(left, right);
@@ -316,7 +307,7 @@ impl FormatBuilder {
         self
     }
 
-    /// Set global indentation in spaces used when rendering a table 
+    /// Set global indentation in spaces used when rendering a table
     pub fn indent(mut self, spaces: usize) -> Self {
         self.format.indent(spaces);
         self
@@ -330,13 +321,13 @@ impl FormatBuilder {
 
 impl Into<TableFormat> for FormatBuilder {
     fn into(self) -> TableFormat {
-        self.into_table_format()
+        *self.format
     }
 }
 
 impl From<TableFormat> for FormatBuilder {
     fn from(fmt: TableFormat) -> Self {
-        Self::from_format(fmt)
+        FormatBuilder { format: Box::new(fmt) }
     }
 }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -225,7 +225,7 @@ impl TableFormat {
                                                    -> Result<(), Error> {
         match *self.get_sep_for_line(pos) {
             Some(ref l) => {
-                write!(out, "{:1$}", "", self.get_indent());
+                out.write_all(&vec![b' '; self.get_indent()]);
                 l._print(out,
                          col_width,
                          self.get_padding(),
@@ -281,6 +281,11 @@ impl FormatBuilder {
         FormatBuilder { format: Box::new(format) }
     }
 
+    /// Consumes the builder and returns the generated `TableFormat`
+    pub fn into_table_format(self) -> TableFormat {
+        *self.format
+    }
+
     /// Set left and right padding
     pub fn padding(mut self, left: usize, right: usize) -> Self {
         self.format.padding(left, right);
@@ -317,9 +322,21 @@ impl FormatBuilder {
         self
     }
 
-    /// Consume this builder and return the generated `TableFormat`
-    pub fn build(self) -> TableFormat {
+    /// Return the generated `TableFormat`
+    pub fn build(&self) -> TableFormat {
         *self.format
+    }
+}
+
+impl Into<TableFormat> for FormatBuilder {
+    fn into(self) -> TableFormat {
+        self.into_table_format()
+    }
+}
+
+impl From<TableFormat> for FormatBuilder {
+    fn from(fmt: TableFormat) -> Self {
+        Self::from_format(fmt)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -767,6 +767,24 @@ mod tests {
     }
 
     #[test]
+    fn indent() {
+        let mut table = Table::new();
+        table.add_row(Row::new(vec![Cell::new("a"), Cell::new("bc"), Cell::new("def")]));
+        table.add_row(Row::new(vec![Cell::new("def"), Cell::new("bc"), Cell::new("a")]));
+        table.set_titles(Row::new(vec![Cell::new("t1"), Cell::new("t2"), Cell::new("t3")]));
+        table.get_format().indent(8);
+        let out = r"        +-----+----+-----+
+        | t1  | t2 | t3  |
+        +=====+====+=====+
+        | a   | bc | def |
+        +-----+----+-----+
+        | def | bc | a   |
+        +-----+----+-----+
+";
+        assert_eq!(table.to_string().replace("\r\n", "\n"), out);
+    }
+
+    #[test]
     fn slices() {
         let mut table = Table::new();
         table.set_titles(Row::new(vec![Cell::new("t1"), Cell::new("t2"), Cell::new("t3")]));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,6 +283,11 @@ impl Table {
         *self.format = format;
     }
 
+    /// Get a mutable reference to the internal format
+    pub fn get_format(&mut self) -> &mut TableFormat {
+        &mut self.format
+    }
+
     /// Compute and return the number of column
     pub fn get_column_num(&self) -> usize {
         self.as_ref().get_column_num()

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ fn main() {
     println!("Modified : ");
     table.set_element("new_foo", 2, 1).unwrap();
     table.printstd();
+    // table.get_format().indent(8);
 
     // Print a table with some styles on it :
     // FrBybl means : Foregound red, Background yellow, bold, left align
@@ -47,6 +48,7 @@ fn main() {
     let mut table = table!([Frb => "A", "B", "C"], [1, 2, 3, 4], ["A\nBCCZZZ\nDDD", 2, table]);
     table.set_titles(row!["Title 1", "Title 2"]);
     table.set_format(*consts::FORMAT_DEFAULT);
+    table.get_format().indent(8);
     table.printstd();
-    //    println!("{:#?}", table);
+    // println!("{:#?}", table);
 }

--- a/src/row.rs
+++ b/src/row.rs
@@ -119,7 +119,8 @@ impl Row {
         where F: Fn(&Cell, &mut T, usize, usize, bool) -> Result<(), Error>
     {
         for i in 0..self.get_height() {
-            out.write_all(&vec![b' '; format.get_indent()]);
+            //TODO: Wrap this into dedicated function one day
+            try!(out.write_all(&vec![b' '; format.get_indent()]));
             try!(format.print_column_separator(out, ColumnPosition::Left));
             let (lp, rp) = format.get_padding();
             for j in 0..col_width.len() {

--- a/src/row.rs
+++ b/src/row.rs
@@ -119,6 +119,7 @@ impl Row {
         where F: Fn(&Cell, &mut T, usize, usize, bool) -> Result<(), Error>
     {
         for i in 0..self.get_height() {
+            write!(out, "{:1$}", "", format.get_indent());
             try!(format.print_column_separator(out, ColumnPosition::Left));
             let (lp, rp) = format.get_padding();
             for j in 0..col_width.len() {

--- a/src/row.rs
+++ b/src/row.rs
@@ -119,7 +119,7 @@ impl Row {
         where F: Fn(&Cell, &mut T, usize, usize, bool) -> Result<(), Error>
     {
         for i in 0..self.get_height() {
-            write!(out, "{:1$}", "", format.get_indent());
+            out.write_all(&vec![b' '; format.get_indent()]);
             try!(format.print_column_separator(out, ColumnPosition::Left));
             let (lp, rp) = format.get_padding();
             for j in 0..col_width.len() {


### PR DESCRIPTION
Added capability to customize indent in `TableFormat`.

## Example
```rust
let mut table!(["A", "B", "C"], [123, 234, 345, 456]);
table.get_format().indent(8);
table.printstd();
```
will print a 8 spaces indented table
```
        +-----+-----+-----+-----+
        | A   | B   |   C |     |
        +-----+-----+-----+-----+
        | 123 | 234 | 345 | 456 |
        +-----+-----+-----+-----+
```

## Open questions
* If an indented table is rendered inside another table, it will still be indented. Is it acceptable ? For example:
```
        +---------+---------+--------------------------------------+---+
        | Title 1 | Title 2 |                                      |   |
        +=========+=========+======================================+===+
        | A       | B       | C                                    |   |
        +---------+---------+--------------------------------------+---+
        | 1       | 2       | 3                                    | 4 |
        +---------+---------+--------------------------------------+---+
        | A       | 2       |         +---------+------+---------+ |   |
        | BCCZZZ  |         |         | ABC     | DEFG | HIJKLMN | |   |
        | DDD     |         |         +---------+------+---------+ |   |
        |         |         |         | foobar  | bar  | new_foo | |   |
        |         |         |         +---------+------+---------+ |   |
        |         |         |         |         |      |         | |   |
        |         |         |         +---------+------+---------+ |   |
        |         |         |         | styled  | bar  | foo     | |   |
        |         |         |         +---------+------+---------+ |   |
        |         |         |         | foobar2 | bar2 | foo2    | |   |
        |         |         |         +---------+------+---------+ |   |
        +---------+---------+--------------------------------------+---+
```
* Is the API user-friendly enough ?

## Still to be done
* [x] Fix warnings
* [x] ~Wrap `write!(out, "{:1$}", "", self.get_indent());` into `TableFormat::print_indent()` ?~
* [x] Unit tests

Closes #51