### PR TITLE
Updated term

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ name = "prettytable"
 
 [dependencies]
 unicode-width = "^0.1"
-term = "^0.4"
+term = "^0.5"
 lazy_static = "1"
 atty = "^0.2"
 encode_unicode = "^0.3"


### PR DESCRIPTION
Hi there, I just updated `term` in my crate which uses this one. It broke because of course `0.4` and `0.5` are per se incompatible.
you should probably reexport those types as they are part of your public api