### PR TITLE
Fixed cell width issues when using ANSI color codes.

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -2,9 +2,9 @@
 
 use std::io::{Write, Error};
 use std::string::ToString;
-use unicode_width::UnicodeWidthStr;
 use super::{Attr, Terminal, color};
 use super::format::Alignment;
+use super::utils::display_width;
 use super::utils::print_align;
 
 /// Represent a table cell containing a string.
@@ -26,7 +26,7 @@ impl Cell {
         let content: Vec<String> = string.lines().map(|x| x.to_string()).collect();
         let mut width = 0;
         for cont in &content {
-            let l = UnicodeWidthStr::width(&cont[..]);
+            let l = display_width(&cont[..]);
             if l > width {
                 width = l;
             }

--- a/src/format.rs
+++ b/src/format.rs
@@ -176,6 +176,16 @@ impl TableFormat {
         self.rborder = Some(border);
     }
 
+    /// Set the character used for left table border
+    pub fn left_border(&mut self, border: char) {
+        self.lborder = Some(border);
+    }
+
+    /// Set the character used for right table border
+    pub fn right_border(&mut self, border: char) {
+        self.rborder = Some(border);
+    }
+
     /// Set a line separator
     pub fn separator(&mut self, what: LinePosition, separator: LineSeparator) {
         *match what {
@@ -292,6 +302,18 @@ impl FormatBuilder {
     /// Set the character used for table borders
     pub fn borders(mut self, border: char) -> Self {
         self.format.borders(border);
+        self
+    }
+
+    /// Set the character used for left table border
+    pub fn left_border(mut self, border: char) -> Self {
+        self.format.left_border(border);
+        self
+    }
+
+    /// Set the character used for right table border
+    pub fn right_border(mut self, border: char) -> Self {
+        self.format.right_border(border);
         self
     }
 


### PR DESCRIPTION
This PR adds a `utils::display_width` function, which is just a wrapper around `UnicodeWidthStr::width` which also takes ANSI color codes into account.

This is required when creating cells from strings which are already colored using ANSI color codes (instead of coloring the cells using styles). Since color codes are of the form `\u{1b}[ ... m`, but UnicodeWidthStr::width only takes the first `\u{1b}` into account, this would create cell width issues.

This solves issue #46.