### PR TITLE
Document set_titles() in README, plus bonus tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,13 +269,14 @@ Configurable settings include:
 - Junctions
 - Column separators
 - Line separators
+- Titles (using `table.set_titles()`)
 
 To do this, either:
 - create a new `TableFormat` object, then call setters until you get the desired configuration;
 - or use the convenient `FormatBuilder` and Builder pattern, shown below
 
 ```rust
-let mut table = /* Initialize table */;
+let mut table = Table::new();
 let format = format::FormatBuilder::new()
     .column_separator('|')
     .borders('|')
@@ -285,6 +286,10 @@ let format = format::FormatBuilder::new()
     .padding(1, 1)
     .build();
 table.set_format(format);
+
+table.set_titles(row!["Title 1", "Title 2"]);
+table.add_row(row!["Value 1", "Value 2"]);
+table.add_row(row!["Value three", "Value four"]);
 ```
 
 The code above will make the table look like
@@ -300,6 +305,8 @@ For convenience, several formats are predefined in `prettytable::format::consts`
 
 Some formats and their respective outputs:
 - ```rust
+  use prettytable::format;
+
   table.set_format(*format::consts::FORMAT_NO_LINESEP_WITH_TITLE);
   ```
   ```
@@ -311,6 +318,8 @@ Some formats and their respective outputs:
   +-------------+------------+
   ```
 - ```rust
+  use prettytable::format;
+
   table.set_format(*format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR);
   ```
   ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -967,6 +967,63 @@ mod tests {
         assert_eq!(out, table.to_string().replace("\r\n", "\n"));
     }
 
+    #[test]
+    fn test_readme_format() {
+
+        // The below is lifted from the README
+
+        let mut table = Table::new();
+        let format = format::FormatBuilder::new()
+            .column_separator('|')
+            .borders('|')
+            .separators(&[format::LinePosition::Top,
+                        format::LinePosition::Bottom],
+                        format::LineSeparator::new('-', '+', '+', '+'))
+            .padding(1, 1)
+            .build();
+        table.set_format(format);
+
+        table.set_titles(Row::new(vec![Cell::new("Title 1"), Cell::new("Title 2")]));
+        table.add_row(Row::new(vec![Cell::new("Value 1"), Cell::new("Value 2")]));
+        table.add_row(Row::new(vec![Cell::new("Value three"), Cell::new("Value four")]));
+
+        let out = "\
++-------------+------------+
+| Title 1     | Title 2    |
+| Value 1     | Value 2    |
+| Value three | Value four |
++-------------+------------+
+";
+
+        println!("{}", out);
+        println!("____");
+        println!("{}", table.to_string().replace("\r\n","\n"));
+        assert_eq!(out, table.to_string().replace("\r\n","\n"));
+    }
+
+    #[test]
+    fn test_readme_format_with_title() {
+        let mut table = Table::new();
+        table.set_format(*format::consts::FORMAT_NO_LINESEP_WITH_TITLE);
+
+        table.set_titles(Row::new(vec![Cell::new("Title 1"), Cell::new("Title 2")]));
+        table.add_row(Row::new(vec![Cell::new("Value 1"), Cell::new("Value 2")]));
+        table.add_row(Row::new(vec![Cell::new("Value three"), Cell::new("Value four")]));
+
+        let out = "\
++-------------+------------+
+| Title 1     | Title 2    |
++-------------+------------+
+| Value 1     | Value 2    |
+| Value three | Value four |
++-------------+------------+
+";
+        println!("{}", out);
+        println!("____");
+        println!("{}", table.to_string().replace("\r\n","\n"));
+        assert_eq!(out, table.to_string().replace("\r\n","\n"));
+    }
+
     #[cfg(feature = "csv")]
     mod csv {
         use Table;


### PR DESCRIPTION
First of all thank you for a wonderful crate! I've just started with Rust and I've been writing a tool to calculate profits of various recipes in No Man's Sky, and `prettytable` has made the formatting of that a breeze!

On that note, this is my first pull-request to a Rust project. Please let me know if I've goofed anything up, and certainly feel free to change things to match style and standards as needed.

This PR adds mention of `set_titles()` to the README, since without that the fancier table formats won't work as expected. (I ended up digging into the code to find it.)

I've also added two test cases in `lib.rs` that explicitly check that code in the README does what it says, and added a mention to `use prettyformat::table` before setting one of the pre-defined formats, as this newbie didn't realise that had to happen and was confused
with the resulting error.

Many thanks again, and all the very best!

~ Paul