### PR TITLE
Refactored modules and reexports

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,7 @@ Start using it like this:
 
 ```rust
 #[macro_use] extern crate prettytable;
-use prettytable::Table;
-use prettytable::row::Row;
-use prettytable::cell::Cell;
+use prettytable::{Table, Row, Cell};
 
 fn main() {
     // Create the table

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,8 +1,6 @@
 #[macro_use]
 extern crate prettytable;
-use prettytable::Table;
-use prettytable::row::Row;
-use prettytable::cell::Cell;
+use prettytable::{Table, Row, Cell};
 
 /*
     Following main function will print :

--- a/examples/span.rs
+++ b/examples/span.rs
@@ -1,6 +1,6 @@
 #[macro_use]
 extern crate prettytable;
-use prettytable::{row::Row, cell::Cell, format::Alignment};
+use prettytable::{Row, Cell, format::Alignment};
 
 
 fn main() {

--- a/examples/style.rs
+++ b/examples/style.rs
@@ -1,8 +1,6 @@
 #[macro_use]
 extern crate prettytable;
-use prettytable::Table;
-use prettytable::row::Row;
-use prettytable::cell::Cell;
+use prettytable::{Table, Row, Cell};
 
 use prettytable::{Attr, color};
 

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -308,10 +308,10 @@ impl Default for Cell {
 #[macro_export]
 macro_rules! cell {
     () => {
-        $crate::cell::Cell::default()
+        $crate::Cell::default()
     };
     ($value:expr) => {
-        $crate::cell::Cell::new(&$value.to_string())
+        $crate::Cell::new(&$value.to_string())
     };
     ($style:ident -> $value:expr) => {
         cell!($value).style_spec(stringify!($style))
@@ -320,7 +320,7 @@ macro_rules! cell {
 
 #[cfg(test)]
 mod tests {
-    use cell::Cell;
+    use Cell;
     use format::Alignment;
     use term::{color, Attr};
     use utils::StringWriter;

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -1,0 +1,79 @@
+//! CSV impl and reexported types
+
+extern crate csv;
+
+pub use self::csv::{Reader, Writer, Result, ReaderBuilder};
+use std::path::Path;
+use std::io::{Read, Write};
+
+impl<'a> super::TableSlice<'a> {
+    /// Write the table to the specified writer.
+    pub fn to_csv<W: Write>(&self, w: W) -> Result<Writer<W>> {
+        self.to_csv_writer(Writer::from_writer(w))
+    }
+
+    /// Write the table to the specified writer.
+    ///
+    /// This allows for format customisation.
+    pub fn to_csv_writer<W: Write>(&self,
+                                mut writer: Writer<W>)
+                                -> Result<Writer<W>> {
+        for title in self.titles {
+            writer.write_record(title.iter().map(|c| c.get_content()))?;
+        }
+        for row in self.rows {
+            writer.write_record(row.iter().map(|c| c.get_content()))?;
+        }
+
+        writer.flush()?;
+        Ok(writer)
+    }
+}
+
+impl super::Table {
+    /// Create a table from a CSV string
+    ///
+    /// For more customisability use `from_csv()`
+    pub fn from_csv_string(csv_s: &str) -> Result<Self> {
+        Ok(Self::from_csv(
+            &mut ReaderBuilder::new()
+                .has_headers(false)
+                .from_reader(csv_s.as_bytes())))
+    }
+
+    /// Create a table from a CSV file
+    ///
+    /// For more customisability use `from_csv()`
+    pub fn from_csv_file<P: AsRef<Path>>(csv_p: P) -> Result<Self> {
+        Ok(Self::from_csv(
+            &mut ReaderBuilder::new()
+                .has_headers(false)
+                .from_path(csv_p)?))
+    }
+
+    /// Create a table from a CSV reader
+    pub fn from_csv<R: Read>(reader: &mut Reader<R>) -> Self {
+        Self::init(reader
+                        .records()
+                        .map(|row| {
+                                super::row::Row::new(row.unwrap()
+                                            .into_iter()
+                                            .map(|cell| super::cell::Cell::new(&cell))
+                                            .collect())
+                            })
+                        .collect())
+    }
+
+    
+    /// Write the table to the specified writer.
+    pub fn to_csv<W: Write>(&self, w: W) -> Result<Writer<W>> {
+        self.as_ref().to_csv(w)
+    }
+
+    /// Write the table to the specified writer.
+    ///
+    /// This allows for format customisation.
+    pub fn to_csv_writer<W: Write>(&self, writer: Writer<W>) -> Result<Writer<W>> {
+        self.as_ref().to_csv_writer(writer)
+    }
+}

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -56,9 +56,9 @@ impl super::Table {
         Self::init(reader
                         .records()
                         .map(|row| {
-                                super::row::Row::new(row.unwrap()
+                                super::Row::new(row.unwrap()
                                             .into_iter()
-                                            .map(|cell| super::cell::Cell::new(&cell))
+                                            .map(|cell| super::Cell::new(&cell))
                                             .collect())
                             })
                         .collect())
@@ -75,5 +75,76 @@ impl super::Table {
     /// This allows for format customisation.
     pub fn to_csv_writer<W: Write>(&self, writer: Writer<W>) -> Result<Writer<W>> {
         self.as_ref().to_csv_writer(writer)
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use {Table, Row, Cell};
+
+    static CSV_S: &'static str = "ABC,DEFG,HIJKLMN\n\
+                                foobar,bar,foo\n\
+                                foobar2,bar2,foo2\n";
+
+    fn test_table() -> Table {
+        let mut table = Table::new();
+        table
+            .add_row(Row::new(vec![Cell::new("ABC"), Cell::new("DEFG"), Cell::new("HIJKLMN")]));
+        table.add_row(Row::new(vec![Cell::new("foobar"), Cell::new("bar"), Cell::new("foo")]));
+        table.add_row(Row::new(vec![Cell::new("foobar2"),
+                                    Cell::new("bar2"),
+                                    Cell::new("foo2")]));
+        table
+    }
+
+    #[test]
+    fn from() {
+        assert_eq!(test_table().to_string().replace("\r\n", "\n"),
+                    Table::from_csv_string(CSV_S)
+                        .unwrap()
+                        .to_string()
+                        .replace("\r\n", "\n"));
+    }
+
+    #[test]
+    fn to() {
+        assert_eq!(
+            String::from_utf8(
+                test_table()
+                    .to_csv(Vec::new())
+                    .unwrap()
+                    .into_inner()
+                    .unwrap()
+                ).unwrap(),
+                CSV_S);
+    }
+
+    #[test]
+    fn trans() {
+        assert_eq!(
+            Table::from_csv_string(
+                &String::from_utf8(
+                    test_table()
+                        .to_csv(Vec::new())
+                        .unwrap()
+                        .into_inner()
+                        .unwrap()
+                ).unwrap()
+            ).unwrap()
+            .to_string()
+            .replace("\r\n", "\n"),
+            test_table().to_string().replace("\r\n", "\n"));
+    }
+
+    #[test]
+    fn extend_table() {
+        let mut table = Table::new();
+        table.add_row(Row::new(vec![Cell::new("ABC"), Cell::new("DEFG"), Cell::new("HIJKLMN")]));
+        table.extend(vec![vec!["A", "B", "C"]]);
+        let t2 = table.clone();
+        table.extend(t2.rows);
+        assert_eq!(table.get_row(1).unwrap().get_cell(2).unwrap().get_content(), "C");
+        assert_eq!(table.get_row(2).unwrap().get_cell(1).unwrap().get_content(), "DEFG");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,7 @@ extern crate lazy_static;
 extern crate encode_unicode;
 
 use std::io::{self, Write, Error};
-#[cfg(feature = "csv")]
-use std::io::Read;
 use std::fmt;
-#[cfg(feature = "csv")]
-use std::path::Path;
 use std::iter::{FromIterator, IntoIterator};
 use std::slice::{Iter, IterMut};
 use std::ops::{Index, IndexMut};
@@ -29,11 +25,85 @@ pub mod row;
 pub mod format;
 mod utils;
 
-/// Reexported types for CSV Read/Write
+/// CSV impl and reexported types
 #[cfg(feature = "csv")]
 pub mod csv {
     extern crate csv;
     pub use self::csv::{Reader, Writer, Result, ReaderBuilder};
+    use std::path::Path;
+    use std::io::{Read, Write};
+
+    impl<'a> super::TableSlice<'a> {
+        /// Write the table to the specified writer.
+        pub fn to_csv<W: Write>(&self, w: W) -> Result<Writer<W>> {
+            self.to_csv_writer(Writer::from_writer(w))
+        }
+
+        /// Write the table to the specified writer.
+        ///
+        /// This allows for format customisation.
+        pub fn to_csv_writer<W: Write>(&self,
+                                    mut writer: Writer<W>)
+                                    -> Result<Writer<W>> {
+            for title in self.titles {
+                writer.write_record(title.iter().map(|c| c.get_content()))?;
+            }
+            for row in self.rows {
+                writer.write_record(row.iter().map(|c| c.get_content()))?;
+            }
+
+            writer.flush()?;
+            Ok(writer)
+        }
+    }
+
+    impl super::Table {
+        /// Create a table from a CSV string
+        ///
+        /// For more customisability use `from_csv()`
+        pub fn from_csv_string(csv_s: &str) -> Result<Self> {
+            Ok(Self::from_csv(
+                &mut ReaderBuilder::new()
+                    .has_headers(false)
+                    .from_reader(csv_s.as_bytes())))
+        }
+
+        /// Create a table from a CSV file
+        ///
+        /// For more customisability use `from_csv()`
+        pub fn from_csv_file<P: AsRef<Path>>(csv_p: P) -> Result<Self> {
+            Ok(Self::from_csv(
+                &mut ReaderBuilder::new()
+                    .has_headers(false)
+                    .from_path(csv_p)?))
+        }
+
+        /// Create a table from a CSV reader
+        pub fn from_csv<R: Read>(reader: &mut Reader<R>) -> Self {
+            Self::init(reader
+                            .records()
+                            .map(|row| {
+                                    super::row::Row::new(row.unwrap()
+                                                .into_iter()
+                                                .map(|cell| super::cell::Cell::new(&cell))
+                                                .collect())
+                                })
+                            .collect())
+        }
+
+        
+        /// Write the table to the specified writer.
+        pub fn to_csv<W: Write>(&self, w: W) -> Result<Writer<W>> {
+            self.as_ref().to_csv(w)
+        }
+
+        /// Write the table to the specified writer.
+        ///
+        /// This allows for format customisation.
+        pub fn to_csv_writer<W: Write>(&self, writer: Writer<W>) -> Result<Writer<W>> {
+            self.as_ref().to_csv_writer(writer)
+        }
+    }
 }
 
 use row::Row;
@@ -207,30 +277,6 @@ impl<'a> TableSlice<'a> {
     pub fn printstd(&self) {
         self.print_tty(false);
     }
-
-    /// Write the table to the specified writer.
-    #[cfg(feature = "csv")]
-    pub fn to_csv<W: Write>(&self, w: W) -> csv::Result<csv::Writer<W>> {
-        self.to_csv_writer(csv::Writer::from_writer(w))
-    }
-
-    /// Write the table to the specified writer.
-    ///
-    /// This allows for format customisation.
-    #[cfg(feature = "csv")]
-    pub fn to_csv_writer<W: Write>(&self,
-                                   mut writer: csv::Writer<W>)
-                                   -> csv::Result<csv::Writer<W>> {
-        for title in self.titles {
-            writer.write_record(title.iter().map(|c| c.get_content()))?;
-        }
-        for row in self.rows {
-            writer.write_record(row.iter().map(|c| c.get_content()))?;
-        }
-
-        writer.flush()?;
-        Ok(writer)
-    }
 }
 
 impl<'a> IntoIterator for &'a TableSlice<'a> {
@@ -254,42 +300,6 @@ impl Table {
             titles: Box::new(None),
             format: Box::new(*consts::FORMAT_DEFAULT),
         }
-    }
-
-    /// Create a table from a CSV string
-    ///
-    /// For more customisability use `from_csv()`
-    #[cfg(feature = "csv")]
-    pub fn from_csv_string(csv_s: &str) -> csv::Result<Table> {
-        Ok(Table::from_csv(
-            &mut csv::ReaderBuilder::new()
-                .has_headers(false)
-                .from_reader(csv_s.as_bytes())))
-    }
-
-    /// Create a table from a CSV file
-    ///
-    /// For more customisability use `from_csv()`
-    #[cfg(feature = "csv")]
-    pub fn from_csv_file<P: AsRef<Path>>(csv_p: P) -> csv::Result<Table> {
-        Ok(Table::from_csv(
-            &mut csv::ReaderBuilder::new()
-                .has_headers(false)
-                .from_path(csv_p)?))
-    }
-
-    /// Create a table from a CSV reader
-    #[cfg(feature = "csv")]
-    pub fn from_csv<R: Read>(reader: &mut csv::Reader<R>) -> Table {
-        Table::init(reader
-                        .records()
-                        .map(|row| {
-                                 Row::new(row.unwrap()
-                                              .into_iter()
-                                              .map(|cell| Cell::new(&cell))
-                                              .collect())
-                             })
-                        .collect())
     }
 
     /// Change the table format. Eg : Separators
@@ -429,19 +439,6 @@ impl Table {
         self.as_ref().printstd();
     }
 
-    /// Write the table to the specified writer.
-    #[cfg(feature = "csv")]
-    pub fn to_csv<W: Write>(&self, w: W) -> csv::Result<csv::Writer<W>> {
-        self.as_ref().to_csv(w)
-    }
-
-    /// Write the table to the specified writer.
-    ///
-    /// This allows for format customisation.
-    #[cfg(feature = "csv")]
-    pub fn to_csv_writer<W: Write>(&self, writer: csv::Writer<W>) -> csv::Result<csv::Writer<W>> {
-        self.as_ref().to_csv_writer(writer)
-    }
 }
 
 impl Index<usize> for Table {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,86 +25,8 @@ pub mod row;
 pub mod format;
 mod utils;
 
-/// CSV impl and reexported types
 #[cfg(feature = "csv")]
-pub mod csv {
-    extern crate csv;
-    pub use self::csv::{Reader, Writer, Result, ReaderBuilder};
-    use std::path::Path;
-    use std::io::{Read, Write};
-
-    impl<'a> super::TableSlice<'a> {
-        /// Write the table to the specified writer.
-        pub fn to_csv<W: Write>(&self, w: W) -> Result<Writer<W>> {
-            self.to_csv_writer(Writer::from_writer(w))
-        }
-
-        /// Write the table to the specified writer.
-        ///
-        /// This allows for format customisation.
-        pub fn to_csv_writer<W: Write>(&self,
-                                    mut writer: Writer<W>)
-                                    -> Result<Writer<W>> {
-            for title in self.titles {
-                writer.write_record(title.iter().map(|c| c.get_content()))?;
-            }
-            for row in self.rows {
-                writer.write_record(row.iter().map(|c| c.get_content()))?;
-            }
-
-            writer.flush()?;
-            Ok(writer)
-        }
-    }
-
-    impl super::Table {
-        /// Create a table from a CSV string
-        ///
-        /// For more customisability use `from_csv()`
-        pub fn from_csv_string(csv_s: &str) -> Result<Self> {
-            Ok(Self::from_csv(
-                &mut ReaderBuilder::new()
-                    .has_headers(false)
-                    .from_reader(csv_s.as_bytes())))
-        }
-
-        /// Create a table from a CSV file
-        ///
-        /// For more customisability use `from_csv()`
-        pub fn from_csv_file<P: AsRef<Path>>(csv_p: P) -> Result<Self> {
-            Ok(Self::from_csv(
-                &mut ReaderBuilder::new()
-                    .has_headers(false)
-                    .from_path(csv_p)?))
-        }
-
-        /// Create a table from a CSV reader
-        pub fn from_csv<R: Read>(reader: &mut Reader<R>) -> Self {
-            Self::init(reader
-                            .records()
-                            .map(|row| {
-                                    super::row::Row::new(row.unwrap()
-                                                .into_iter()
-                                                .map(|cell| super::cell::Cell::new(&cell))
-                                                .collect())
-                                })
-                            .collect())
-        }
-
-        
-        /// Write the table to the specified writer.
-        pub fn to_csv<W: Write>(&self, w: W) -> Result<Writer<W>> {
-            self.as_ref().to_csv(w)
-        }
-
-        /// Write the table to the specified writer.
-        ///
-        /// This allows for format customisation.
-        pub fn to_csv_writer<W: Write>(&self, writer: Writer<W>) -> Result<Writer<W>> {
-            self.as_ref().to_csv_writer(writer)
-        }
-    }
-}
+pub mod csv;
 
 use row::Row;
 use cell::Cell;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,16 +20,16 @@ use std::mem::transmute;
 pub use term::{Attr, color};
 pub(crate) use term::{Terminal, stdout};
 
-pub mod cell;
-pub mod row;
+mod cell;
+mod row;
 pub mod format;
 mod utils;
 
 #[cfg(feature = "csv")]
 pub mod csv;
 
-use row::Row;
-use cell::Cell;
+pub use row::Row;
+pub use cell::Cell;
 use format::{TableFormat, LinePosition, consts};
 use utils::StringWriter;
 
@@ -575,8 +575,8 @@ macro_rules! ptable {
 mod tests {
     use Table;
     use Slice;
-    use row::Row;
-    use cell::Cell;
+    use Row;
+    use Cell;
     use format;
     use format::consts::{FORMAT_DEFAULT, FORMAT_NO_LINESEP, FORMAT_NO_COLSEP, FORMAT_CLEAN};
 
@@ -976,77 +976,5 @@ mod tests {
         println!("____");
         println!("{}", table.to_string().replace("\r\n","\n"));
         assert_eq!(out, table.to_string().replace("\r\n","\n"));
-    }
-
-    #[cfg(feature = "csv")]
-    mod csv {
-        use Table;
-        use row::Row;
-        use cell::Cell;
-
-        static CSV_S: &'static str = "ABC,DEFG,HIJKLMN\n\
-                                  foobar,bar,foo\n\
-                                  foobar2,bar2,foo2\n";
-
-        fn test_table() -> Table {
-            let mut table = Table::new();
-            table
-                .add_row(Row::new(vec![Cell::new("ABC"), Cell::new("DEFG"), Cell::new("HIJKLMN")]));
-            table.add_row(Row::new(vec![Cell::new("foobar"), Cell::new("bar"), Cell::new("foo")]));
-            table.add_row(Row::new(vec![Cell::new("foobar2"),
-                                        Cell::new("bar2"),
-                                        Cell::new("foo2")]));
-            table
-        }
-
-        #[test]
-        fn from() {
-            assert_eq!(test_table().to_string().replace("\r\n", "\n"),
-                       Table::from_csv_string(CSV_S)
-                           .unwrap()
-                           .to_string()
-                           .replace("\r\n", "\n"));
-        }
-
-        #[test]
-        fn to() {
-            assert_eq!(
-                String::from_utf8(
-                    test_table()
-                        .to_csv(Vec::new())
-                        .unwrap()
-                        .into_inner()
-                        .unwrap()
-                    ).unwrap(),
-                    CSV_S);
-        }
-
-        #[test]
-        fn trans() {
-            assert_eq!(
-                Table::from_csv_string(
-                    &String::from_utf8(
-                        test_table()
-                            .to_csv(Vec::new())
-                            .unwrap()
-                            .into_inner()
-                            .unwrap()
-                    ).unwrap()
-                ).unwrap()
-                .to_string()
-                .replace("\r\n", "\n"),
-                test_table().to_string().replace("\r\n", "\n"));
-        }
-
-        #[test]
-        fn extend_table() {
-            let mut table = Table::new();
-            table.add_row(Row::new(vec![Cell::new("ABC"), Cell::new("DEFG"), Cell::new("HIJKLMN")]));
-            table.extend(vec![vec!["A", "B", "C"]]);
-            let t2 = table.clone();
-            table.extend(t2.rows);
-            assert_eq!(table.get_row(1).unwrap().get_cell(2).unwrap().get_content(), "C");
-            assert_eq!(table.get_row(2).unwrap().get_cell(1).unwrap().get_content(), "DEFG");
-        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,8 @@
 #[macro_use]
 extern crate prettytable;
 use prettytable::Table;
-use prettytable::row::Row;
-use prettytable::cell::Cell;
+use prettytable::Row;
+use prettytable::Cell;
 use prettytable::format::*;
 use prettytable::{Attr, color};
 

--- a/src/row.rs
+++ b/src/row.rs
@@ -8,7 +8,7 @@ use std::ops::{Index, IndexMut};
 use super::Terminal;
 
 use super::utils::NEWLINE;
-use super::cell::Cell;
+use super::Cell;
 use super::format::{TableFormat, ColumnPosition};
 
 /// Represent a table row made of cells
@@ -312,16 +312,16 @@ macro_rules! row {
     (($($out:tt)*); $style:ident -> $value:expr) => (vec![$($out)* cell!($style -> $value)]);
     (($($out:tt)*); $style:ident -> $value:expr, $($n: tt)*) => (row!(($($out)* cell!($style -> $value),); $($n)*));
 
-    ($($content:expr), *) => ($crate::row::Row::new(vec![$(cell!($content)), *])); // This line may not be needed starting from Rust 1.20
-    ($style:ident => $($content:expr), *) => ($crate::row::Row::new(vec![$(cell!($style -> $content)), *]));
-    ($style:ident => $($content:expr,) *) => ($crate::row::Row::new(vec![$(cell!($style -> $content)), *]));
-    ($($content:tt)*) => ($crate::row::Row::new(row!((); $($content)*)));
+    ($($content:expr), *) => ($crate::Row::new(vec![$(cell!($content)), *])); // This line may not be needed starting from Rust 1.20
+    ($style:ident => $($content:expr), *) => ($crate::Row::new(vec![$(cell!($style -> $content)), *]));
+    ($style:ident => $($content:expr,) *) => ($crate::Row::new(vec![$(cell!($style -> $content)), *]));
+    ($($content:tt)*) => ($crate::Row::new(row!((); $($content)*)));
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cell::Cell;
+    use Cell;
 
     #[test]
     fn row_default_empty() {


### PR DESCRIPTION
* Reexported types used from `csv` crate
* Moved CSV stuff in dedicated module
* Reexport `cell::Cell` and `row::Row` into crate's root
* `cell` and `row` modules are now private