### PR TITLE
Fix macros for selective import via `use`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: rust
 rust:
-- 1.26.2
-- 1.27.2
-- 1.28.0
-- 1.29.0
+- 1.30.0
 - stable
 - beta
 - nightly

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Include the library as a dependency to your project by adding the following line
 prettytable-rs = "^0.8"
 ```
 
-The library requires at least `rust v1.26.0`.
+The library requires at least `rust v1.30.0`.
 
 ## Basic usage
 

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -314,7 +314,7 @@ macro_rules! cell {
         $crate::Cell::new(&$value.to_string())
     };
     ($style:ident -> $value:expr) => {
-        cell!($value).style_spec(stringify!($style))
+        $crate::cell!($value).style_spec(stringify!($style))
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -567,7 +567,7 @@ impl<'a, T, E> Slice<'a, E> for T
 #[macro_export]
 macro_rules! table {
     ($([$($content:tt)*]), *) => (
-        $crate::Table::init(vec![$(row![$($content)*]), *])
+        $crate::Table::init(vec![$($crate::row![$($content)*]), *])
     );
 }
 
@@ -578,7 +578,7 @@ macro_rules! table {
 macro_rules! ptable {
     ($($content:tt)*) => (
         {
-            let tab = table!($($content)*);
+            let tab = $crate::table!($($content)*);
             tab.printstd();
             tab
         }

--- a/src/row.rs
+++ b/src/row.rs
@@ -304,15 +304,15 @@ impl <S: ToString> Extend<S> for Row {
 #[macro_export]
 macro_rules! row {
     (($($out:tt)*);) => (vec![$($out)*]);
-    (($($out:tt)*); $value:expr) => (vec![$($out)* cell!($value)]);
-    (($($out:tt)*); $value:expr, $($n:tt)*) => (row!(($($out)* cell!($value),); $($n)*));
-    (($($out:tt)*); $style:ident -> $value:expr) => (vec![$($out)* cell!($style -> $value)]);
-    (($($out:tt)*); $style:ident -> $value:expr, $($n: tt)*) => (row!(($($out)* cell!($style -> $value),); $($n)*));
+    (($($out:tt)*); $value:expr) => (vec![$($out)* $crate::cell!($value)]);
+    (($($out:tt)*); $value:expr, $($n:tt)*) => ($crate::row!(($($out)* $crate::cell!($value),); $($n)*));
+    (($($out:tt)*); $style:ident -> $value:expr) => (vec![$($out)* $crate::cell!($style -> $value)]);
+    (($($out:tt)*); $style:ident -> $value:expr, $($n: tt)*) => ($crate::row!(($($out)* $crate::cell!($style -> $value),); $($n)*));
 
-    ($($content:expr), *) => ($crate::Row::new(vec![$(cell!($content)), *])); // This line may not be needed starting from Rust 1.20
-    ($style:ident => $($content:expr), *) => ($crate::Row::new(vec![$(cell!($style -> $content)), *]));
-    ($style:ident => $($content:expr,) *) => ($crate::Row::new(vec![$(cell!($style -> $content)), *]));
-    ($($content:tt)*) => ($crate::Row::new(row!((); $($content)*)));
+    ($($content:expr), *) => ($crate::Row::new(vec![$($crate::cell!($content)), *])); // This line may not be needed starting from Rust 1.20
+    ($style:ident => $($content:expr), *) => ($crate::Row::new(vec![$($crate::cell!($style -> $content)), *]));
+    ($style:ident => $($content:expr,) *) => ($crate::Row::new(vec![$($crate::cell!($style -> $content)), *]));
+    ($($content:tt)*) => ($crate::Row::new($crate::row!((); $($content)*)));
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Allow the import of any macro with `use` while not requiring the user
to import macros that are invoked by the imported macro.

This feature was add with Rust 1.30, so adjust the travis build and
README accordingly.

This fixes issue #99.