### PR TITLE
Creation of prettytable-rs-derive and the creation of table from vector

### DIFF
--- a/prettytable-rs-derive/.gitignore
+++ b/prettytable-rs-derive/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/Cargo.lock
+
+\.vscode/

--- a/prettytable-rs-derive/Cargo.toml
+++ b/prettytable-rs-derive/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "prettytable-rs-derive"
+version = "0.1.0"
+authors = ["Andrea Stevanato <andrea.stevanato.95@hotmail.it>"]
+edition = "2018"
+
+[dependencies]
+syn = {version = "0.15.42", features = ["full"]}
+quote = "0.6.13"
+prettytable-rs = { path = "../" }
+
+[lib]
+proc-macro = true
+name = "prettytable_derive"

--- a/prettytable-rs-derive/src/lib.rs
+++ b/prettytable-rs-derive/src/lib.rs
@@ -1,0 +1,29 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, ItemStruct};
+
+#[proc_macro_derive(TableElem)]
+pub fn derive_table_elem(input: TokenStream) -> TokenStream {
+    let parsed_input = parse_macro_input!(input as ItemStruct);
+
+    let struct_name = &parsed_input.ident;
+    let field = &parsed_input.fields;
+
+    // Get struct field name
+    let f_name: Vec<syn::Ident> = field.iter().map(|f| f.ident.clone().unwrap()).collect();
+    let f_name_str: Vec<String> = f_name.iter().map(|f| f.to_string()).collect();
+
+    TokenStream::from(quote! {
+        impl prettytable::TableElem for #struct_name {
+            fn get_field_name() -> Vec<&'static str> {
+                vec![#(#f_name_str),*]
+            }
+
+            fn get_field(self) -> Vec<String> {
+                vec![#(self.#f_name.into()),*]
+            }
+        }
+    })
+}

--- a/prettytable-rs-derive/tests/derive_test.rs
+++ b/prettytable-rs-derive/tests/derive_test.rs
@@ -1,0 +1,23 @@
+use prettytable_derive::TableElem;
+use prettytable::TableElem;
+
+#[derive(TableElem)]
+struct NameStruct {
+	name: String,
+	surname: String,
+}
+
+#[test]
+fn test_get_field_name() {
+    assert_eq!(vec!["name", "surname"], NameStruct::get_field_name());
+}
+
+#[test]
+fn test_get_field() {
+    let t = NameStruct {
+        name: "real_name".to_string(),
+        surname: "real_surname".to_string(),
+    };
+
+    assert_eq!(vec!["real_name", "real_surname"], t.get_field());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,6 +388,40 @@ impl Table {
     pub fn print_html<T: Write + ?Sized>(&self, out: &mut T) -> Result<(), Error> {
         self.as_ref().print_html(out)
     }
+
+	/// Construct the table from the `TableElem` elements vector.
+	/// 
+	/// A struct may implements the `TableElem` trait using the derive proc-macro 
+	/// from `prettytable-rs-derive` crate
+	pub fn from_vec<T: TableElem>(v: Vec<T>) -> Self {
+		// Create the table
+		let mut table = Self::new();
+
+		// Set the table titles with the name of the struct fields
+		table.set_titles(Row::new(
+			T::get_field_name()
+				.iter()
+				.map(|f| Cell::new(f))
+				.collect(),
+		));
+
+		v.into_iter().for_each(|r| {
+			table.add_row(Row::new(
+				r.get_field().iter().map(|elem| Cell::new(elem)).collect(),
+			));
+		});
+
+		table
+	}
+}
+
+/// A table may be costructed from a vector of elements that implements the 
+/// `TableElem` trait 
+pub trait TableElem {
+	/// Returns a vector containing the name of the struct fields
+	fn get_field_name() -> Vec<&'static str>;
+	/// Returns a vector that contains the contents of the struct's fields
+	fn get_field(self) -> Vec<String>;
 }
 
 impl Index<usize> for Table {


### PR DESCRIPTION
> Pull request referring to the issue #109 

Sorry for the mess that I've made trying to improve the `TableElem` method removing `&self` from `get_field_name`
The code is already rebased. This should be a kind of final code which is the results of the previous commit and pull request https://github.com/phsym/prettytable-rs/pull/110