### PR TITLE
Removed encode-unicode dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,4 @@ unicode-width = "0.1"
 term = "0.6"
 lazy_static = "1"
 atty = "0.2"
-encode_unicode = "0.3"
 csv = { version = "1", optional = true }

--- a/src/format.rs
+++ b/src/format.rs
@@ -2,8 +2,6 @@
 
 use std::io::{Write, Error};
 
-use encode_unicode::Utf8Char;
-
 use super::utils::NEWLINE;
 
 /// Alignment for cell's content
@@ -78,19 +76,19 @@ impl LineSeparator {
                                  rborder: bool)
                                  -> Result<usize, Error> {
         if lborder {
-            out.write_all(Utf8Char::from(self.ljunc).as_bytes())?;
+            out.write(self.ljunc.encode_utf8(&mut [0;4]).as_bytes())?;
         }
         let mut iter = col_width.iter().peekable();
         while let Some(width) = iter.next() {
             for _ in 0..width + padding.0 + padding.1 {
-                out.write_all(Utf8Char::from(self.line).as_bytes())?;
+                out.write(self.line.encode_utf8(&mut [0;4]).as_bytes())?;
             }
             if colsep && iter.peek().is_some() {
-                out.write_all(Utf8Char::from(self.junc).as_bytes())?;
+                out.write(self.junc.encode_utf8(&mut [0;4]).as_bytes())?;
             }
         }
         if rborder {
-            out.write_all(Utf8Char::from(self.rjunc).as_bytes())?;
+            out.write(self.rjunc.encode_utf8(&mut [0;4]).as_bytes())?;
         }
         out.write_all(NEWLINE)?;
         Ok(1)
@@ -258,7 +256,7 @@ impl TableFormat {
                                                      pos: ColumnPosition)
                                                      -> Result<(), Error> {
         match self.get_column_separator(pos) {
-            Some(s) => out.write_all(Utf8Char::from(s).as_bytes()),
+            Some(s) => out.write(s.encode_utf8(&mut [0;4]).as_bytes()).map(|_| ()),
             None => Ok(()),
         }
     }


### PR DESCRIPTION
The reason for attempting to remove this is that encode-unicode provides
some additional iterators that can make some type inferences break by
including it (or a crate that depends on it, like prettytable-rs).

For example, the following line of code works as expected if you include
the rand crate:

```
use rand::thread_rng;
use rand::distributions::{Distribution, Standard};

fn main() {
  let mut rng = thread_rng();
  let v: Vec<u8> = Standard.sample_iter(&mut rng).take(5).collect();
  println!("{:}", v);
}
```

However, once prettytable-rs is included and used, the types will no
longer be able to be inferred.

```
error[E0282]: type annotations needed
  --> src/main.rs:16:31
   |
16 |     let v: Vec<u8> = Standard.sample_iter(&mut rng).take(5).collect();
   |                               ^^^^^^^^^^^
   |                               |
   |                               cannot infer type for type parameter `T`
```
The reason that this occurs is because prettytable includes encode-unicode, which itself adds additional ways that a `Vec<u8>` can be created (specifically from an `Iterator<Utf8Char>`) Since Rust cannot tell if `Standard.sample_iter` might return an `Iterator<Utf8Char>` vs an `Iterator<u8>`, it cannot provide type inference.

To be sure, this is not technically a bug, nor does it even need to be fixed. Type inference breaks are not really considered "breaking changes", but it can be a pain
point. Seeing that prettytable-rs doesn't seem to make much use of the
additional items in encode-unicode, perhaps it's not worth the pain to
users to include it.