### PR TITLE
Update term dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rust:
 - beta
 - nightly
 script:
+- if echo $TRAVIS_RUST_VERSION | grep -qe 1.3[23].0; then cargo update --package term --precise 0.6.0; fi
 - cargo build --verbose --no-default-features
 - cargo test --verbose --no-default-features
 - cargo build --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ name = "prettytable"
 
 [dependencies]
 unicode-width = "0.1"
-term = "0.6"
+term = ">=0.6,<=0.7"
 lazy_static = "1"
 atty = "0.2"
 encode_unicode = "0.3"


### PR DESCRIPTION
Not quite the same as #132. If you want Rust 1.32 support, you can still force term 0.6 as a dependency. (Can't test travis though.)

Though honestly: It's high time to drop those.