### PR TITLE
Mark crate as `deprecated` on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,19 +7,18 @@ homepage = "https://github.com/phsym/prettytable-rs"
 repository = "https://github.com/phsym/prettytable-rs"
 documentation = "https://docs.rs/crate/prettytable-rs/"
 readme = "README.md"
-authors = [ "Pierre-Henri Symoneaux" ]
+authors = ["Pierre-Henri Symoneaux"]
 keywords = ["tab", "table", "format", "pretty", "print"]
 categories = ["command-line-interface"]
 license = "BSD-3-Clause"
 edition = "2018"
-exclude = [
-    "prettytable-evcxr.png"
-]
+exclude = ["prettytable-evcxr.png"]
 
 [badges]
-appveyor = { repository = "phsym/prettytable-rs", branch = "master", service = "github" }
-travis-ci = { repository = "phsym/prettytable-rs", branch = "master" }
-codecov = { repository = "phsym/prettytable-rs", branch = "master", service = "github" }
+maintenance = { status="deprecated" }
+appveyor = { repository="phsym/prettytable-rs", branch="master", service="github" }
+travis-ci = { repository="phsym/prettytable-rs", branch="master" }
+codecov = { repository="phsym/prettytable-rs", branch="master", service="github" }
 
 [features]
 default = ["win_crlf", "csv"]
@@ -40,4 +39,4 @@ term = "0.6"
 lazy_static = "1"
 atty = "0.2"
 encode_unicode = "0.3"
-csv = { version = "1", optional = true }
+csv = { version="1", optional=true }


### PR DESCRIPTION
This crate hasn't received a single commit or merged PR since about three years.
There also doesn't seem to be any intent of the crate author to continue working on this.

My proposal to @phsym is to mark this crate as deprecated so other people will think about using it twice.
I stumbled upon this library about two years ago myself and had to find out the hard way that it has been abandoned, after already spending a few hours working with it.
I guess it could be considered technical debt to use libraries that haven't received any updates since more than three years.

Furthermore, you should consider archiving this repository. Otherwise people will continue spending their time on PRs that'll never get merged.

This PR sets the `deprecated` badge on crates.io. A small patch release would have to be pushed for the badge to show up on https://crates.io/crates/prettytable-rs though.
Sadly, there's no mechanism to mark a crate as `abandoned` from the outside yet, which is why this has to be done manually by @phsym.

This isn't intended to offend or blame anyone. Priorities shift all the time, there's no shame in leaving a project behind.
This PR is just a measure to keep the Rust ecosystem clean.