### PR TITLE
Update CSV dependency and remove is_terminal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,5 @@ name = "prettytable"
 unicode-width = "0.1"
 term = "0.7"
 lazy_static = "1.4"
-is-terminal = "0.4"
 encode_unicode = "1.0"
-csv = { version = "1.1", optional = true }
+csv = { version = "1.3", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ impl<'a> TableSlice<'a> {
     /// # Returns
     /// A `Result` holding the number of lines printed, or an `io::Error` if any failure happens
     pub fn print_tty(&self, force_colorize: bool) -> Result<usize, Error> {
-        use is_terminal::IsTerminal;
+        use std::io::IsTerminal;
         match (stdout(), io::stdout().is_terminal() || force_colorize) {
             (Some(mut o), true) => self.print_term(&mut *o),
             _ => self.print(&mut io::stdout()),


### PR DESCRIPTION
The `is_terminal` documentation says

> As of Rust 1.70, most users should use the [IsTerminal](https://doc.rust-lang.org/stable/std/io/trait.IsTerminal.html) trait in the Rust standard library instead of this crate.
