### PR TITLE
feat: make `is_terminal` replaceble with `std` implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["tab", "table", "format", "pretty", "print"]
 categories = ["command-line-interface"]
 license = "BSD-3-Clause"
 edition = "2018"
+rust-version = "1.56.1"
 exclude = [
     "prettytable-evcxr.png"
 ]
@@ -23,9 +24,14 @@ codecov = { repository = "phsym/prettytable-rs", branch = "master", service = "g
 maintenance = { status = "passively-maintained" }
 
 [features]
-default = ["win_crlf", "csv"]
+# TODO: use `dep:` syntax here and below once MSRV is at least `1.60`
+default = ["win_crlf", "csv", "legacy-is-terminal"]
 evcxr = []
 win_crlf = []
+# This feature is inentionally opt-out (enabled by default) not to break older clients,
+# although it may become no-op with a MSRV bummp (which is considered a minor change) and removed with a major update
+# TODO: make this feature no-op once MSRV is at least `1.70`
+legacy-is-terminal = ["is-terminal"]
 
 [[bin]]
 name = "main"
@@ -39,6 +45,6 @@ name = "prettytable"
 unicode-width = "0.1"
 term = "0.7"
 lazy_static = "1.4"
-is-terminal = "0.4"
+is-terminal = { version = "0.4", optional = true }
 encode_unicode = "1.0"
 csv = { version = "1.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,9 @@ maintenance = { status = "passively-maintained" }
 
 [features]
 # TODO: use `dep:` syntax here and below once MSRV is at least `1.60`
-default = ["win_crlf", "csv", "legacy-is-terminal"]
+default = ["win_crlf", "csv"]
 evcxr = []
 win_crlf = []
-# This feature is inentionally opt-out (enabled by default) not to break older clients,
-# although it may become no-op with a MSRV bummp (which is considered a minor change) and removed with a major update
-# TODO: make this feature no-op once MSRV is at least `1.70`
-legacy-is-terminal = ["is-terminal"]
 
 [[bin]]
 name = "main"
@@ -45,6 +41,9 @@ name = "prettytable"
 unicode-width = "0.1"
 term = "0.7"
 lazy_static = "1.4"
-is-terminal = { version = "0.4", optional = true }
 encode_unicode = "1.0"
 csv = { version = "1.1", optional = true }
+
+# TODO: remove it once MSRV is at least `1.70`
+[target.'cfg(not(prettytable_is_terminal_implementation = "std"))'.dependencies]
+is-terminal = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,9 +194,9 @@ impl<'a> TableSlice<'a> {
     /// # Returns
     /// A `Result` holding the number of lines printed, or an `io::Error` if any failure happens
     pub fn print_tty(&self, force_colorize: bool) -> Result<usize, Error> {
-        #[cfg(not(feature = "legacy-is-terminal"))]
+        #[cfg(prettytable_is_terminal_implementation = "std")]
         use std::io::IsTerminal;
-        #[cfg(feature = "legacy-is-terminal")]
+        #[cfg(not(prettytable_is_terminal_implementation = "std"))]
         use is_terminal::IsTerminal;
 
         match (stdout(), io::stdout().is_terminal() || force_colorize) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,11 @@ impl<'a> TableSlice<'a> {
     /// # Returns
     /// A `Result` holding the number of lines printed, or an `io::Error` if any failure happens
     pub fn print_tty(&self, force_colorize: bool) -> Result<usize, Error> {
+        #[cfg(not(feature = "legacy-is-terminal"))]
+        use std::io::IsTerminal;
+        #[cfg(feature = "legacy-is-terminal")]
         use is_terminal::IsTerminal;
+
         match (stdout(), io::stdout().is_terminal() || force_colorize) {
             (Some(mut o), true) => self.print_term(&mut *o),
             _ => self.print(&mut io::stdout()),


### PR DESCRIPTION
# Description

This adds an opt-out `legacy-is-terminal` feature whose **absence** enables the use of [`std`'s](https://doc.rust-lang.org/std/io/trait.IsTerminal.html) `IsTerminal` instead of [`is-termminal`'s](https://docs.rs/is-terminal/latest/is_terminal/trait.IsTerminal.html).

This way users of Rust 1.70+ will be able to remove `is-terminal`'s dependency tree from their dependencies while not breaking.

The only potential breakage is for users who both:
* use Rust <1.70;
* disable default features;
* have this dependency as a transitive.

Which seems to be very rare (if observable at all).

This is to follow @pinkforest's [suggestion](https://github.com/phsym/prettytable-rs/pull/157#issuecomment-1821612201) that MSRV bump to 1.70 cannot be done for now.

# Alternatives

Considering that (any) change requires a version bump anyway, I would prefer the feature to be opt-out (i.e. use `std` by default and only fall back to `is-terminal` if explicitly required by a non-default feature) which would be more logical and more supportive towards those who use newer Rust versions.