### PR TITLE
Fix HTML output for title rows

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -7,6 +7,13 @@ use std::io::{Error, Write};
 use std::str::FromStr;
 use std::string::ToString;
 
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum CellType {
+    Head,
+    Data
+}
+
 /// Represent a table cell containing a string.
 ///
 /// Once created, a cell's content cannot be modified.
@@ -18,6 +25,7 @@ pub struct Cell {
     align: Alignment,
     style: Vec<Attr>,
     hspan: usize,
+    cell_type: CellType
 }
 
 impl Cell {
@@ -38,6 +46,7 @@ impl Cell {
             align,
             style: Vec::new(),
             hspan: 1,
+            cell_type: CellType::Data
         }
     }
 
@@ -66,6 +75,12 @@ impl Cell {
     /// Add horizontal spanning to the cell
     pub fn with_hspan(mut self, hspan: usize) -> Cell {
         self.set_hspan(hspan);
+        self
+    }
+
+    /// Set cell type (head or data)
+    pub fn with_cell_type(mut self, cell_type: CellType) -> Cell {
+        self.set_cell_type(cell_type);
         self
     }
 
@@ -197,6 +212,16 @@ impl Cell {
         self.hspan
     }
 
+    /// Set type for this cell (head or data)
+    pub fn set_cell_type(&mut self, cell_type: CellType) {
+        self.cell_type = cell_type;
+    }
+
+    /// Get type of this cell (head or data)
+    pub fn get_cell_type(&self) -> CellType {
+        self.cell_type.clone()
+    }
+
     /// Return a copy of the full string contained in the cell
     pub fn get_content(&self) -> String {
         self.content.join("\n")
@@ -306,10 +331,14 @@ impl Cell {
         let content = self.content.join("<br />");
         out.write_all(
             format!(
-                "<td{1} style=\"{2}\">{0}</td>",
+                "<{3}{1} style=\"{2}\">{0}</{3}>",
                 HtmlEscape(&content),
                 colspan,
-                styles
+                styles,
+                match self.cell_type {
+                    CellType::Head => "th",
+                    CellType::Data => "td",
+                }
             )
             .as_bytes(),
         )?;
@@ -345,6 +374,7 @@ impl Default for Cell {
             align: Alignment::LEFT,
             style: Vec::new(),
             hspan: 1,
+            cell_type: CellType::Data
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub mod csv;
 #[cfg(feature = "evcxr")]
 pub mod evcxr;
 
-pub use cell::Cell;
+pub use cell::{Cell, CellType};
 use format::{consts, LinePosition, TableFormat};
 pub use row::Row;
 use utils::StringWriter;
@@ -218,9 +218,9 @@ impl<'a> TableSlice<'a> {
         out.write_all(b"<table>")?;
         // Print titles / table header
         if let Some(ref t) = *self.titles {
-            out.write_all(b"<th>")?;
+            out.write_all(b"<tr>")?;
             t.print_html(out, column_num)?;
-            out.write_all(b"</th>")?;
+            out.write_all(b"</tr>")?;
         }
         // Print rows
         for r in self.rows {
@@ -285,7 +285,8 @@ impl Table {
     }
 
     /// Set the optional title lines
-    pub fn set_titles(&mut self, titles: Row) {
+    pub fn set_titles(&mut self, mut titles: Row) {
+        titles.set_cell_type(CellType::Head);
         *self.titles = Some(titles);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1251,7 +1251,7 @@ mod tests {
         ]));
         let out = "\
 <table>\
-<th><td style=\"text-align: left;\">t1</td><td style=\"text-align: left;\">t2</td><td style=\"text-align: left;\">t3</td></th>\
+<tr><th style=\"text-align: left;\">t1</th><th style=\"text-align: left;\">t2</th><th style=\"text-align: left;\">t3</th></tr>\
 <tr><td style=\"text-align: left;\">a</td><td style=\"text-align: left;\">bc</td><td style=\"text-align: left;\">def</td></tr>\
 <tr><td style=\"text-align: left;\">def</td><td style=\"text-align: left;\">bc</td><td style=\"text-align: left;\">a</td></tr>\
 </table>";
@@ -1297,7 +1297,7 @@ mod tests {
         ));
         let out = "\
 <table>\
-<th><td colspan=\"3\" style=\"text-align: left;\">span horizontal</td></th>\
+<tr><th colspan=\"3\" style=\"text-align: left;\">span horizontal</th></tr>\
 <tr><td style=\"font-weight: bold;text-align: left;\">bold</td><td style=\"font-style: italic;text-align: left;\">italic</td><td style=\"text-decoration: underline;text-align: left;\">underline</td></tr>\
 <tr><td style=\"text-align: left;\">left</td><td style=\"text-align: center;\">center</td><td style=\"text-align: right;\">right</td></tr>\
 <tr><td style=\"color: #aa0000;text-align: left;\">red</td><td style=\"color: #000000;text-align: left;\">black</td><td style=\"color: #aa5500;text-align: left;\">yellow</td></tr>\

--- a/src/row.rs
+++ b/src/row.rs
@@ -9,7 +9,7 @@ use super::Terminal;
 
 use super::format::{ColumnPosition, TableFormat};
 use super::utils::NEWLINE;
-use super::Cell;
+use super::{Cell, CellType};
 
 /// Represent a table row made of cells
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
@@ -140,6 +140,13 @@ impl Row {
         self.cells.iter_mut()
     }
 
+    /// Set cell type for all cells in this row
+    pub fn set_cell_type(&mut self, cell_type: CellType) {
+        for c in self.iter_mut() {
+            c.set_cell_type(cell_type.clone());
+        }
+    }
+
     /// Internal only
     fn __print<T: Write + ?Sized, F>(
         &self,
@@ -221,6 +228,7 @@ impl Row {
     /// Print the row in HTML format to `out`.
     ///
     /// If the row is has fewer columns than `col_num`, the row is padded with empty cells.
+    /// Parameter `title` tells, if the row is a title-row
     pub fn print_html<T: Write + ?Sized>(&self, out: &mut T, col_num: usize) -> Result<(), Error> {
         let mut printed_columns = 0;
         for cell in self.iter() {


### PR DESCRIPTION
As described in #159 , `.print_html()` produced wrong html for title-rows.

This PR fixes this issue by introducing a boolean `title` flag in `Cell::print_html` / `Row::print_html` to select the appropriate tag (`td` or `th`).