### PR TITLE
Fix invalid cell width calculation with modern unicode-width versions 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,10 @@ path = "src/main.rs"
 name = "prettytable"
 
 [dependencies]
-unicode-width = "0.1"
+unicode-width = "0.2"
 term = "0.7"
 lazy_static = "1.4"
 is-terminal = "0.4"
 encode_unicode = "1.0"
+strip-ansi-escapes = "0.2"
 csv = { version = "1.1", optional = true }

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -17,8 +17,8 @@ impl<'a> super::TableSlice<'a> {
     ///
     /// This allows for format customisation.
     pub fn to_csv_writer<W: Write>(&self, mut writer: Writer<W>) -> Result<Writer<W>> {
-        for title in self.titles {
-            writer.write_record(title.iter().map(|c| c.get_content()))?;
+        if let Some(titles) = self.titles {
+            writer.write_record(titles.iter().map(|c| c.get_content()))?;
         }
         for row in self.rows {
             writer.write_record(row.iter().map(|c| c.get_content()))?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -184,4 +184,13 @@ mod tests {
         let res = out.write_all(&[0, 255]);
         assert!(res.is_err());
     }
+
+    #[test]
+    fn display_width_calculation() {
+        assert_eq!(display_width("ASCII text"), 10);
+        assert_eq!(display_width(" ASCII\r\ntext with\nspaces "), 24);
+
+        assert_eq!(display_width("Не-ASCII текст"), 14);
+        assert_eq!(display_width("Colored \u{1B}[2mне-ASCII\u{1B}[0m текст"), 22);
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/phsym/prettytable-rs/issues/165